### PR TITLE
修改添加 format-detection meta 的方法

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -55,11 +55,14 @@ const Layout = ({ children }) => (
               name: 'keywords',
               content: data.site.siteMetadata.keywords.join(','),
             },
+            {
+              name: 'format-detection',
+              content: 'telephone=no,date=no,address=no,email=no,url=no'
+            },
           ]}
           link={[{ rel: 'shortcut icon', type: 'image/png', href: `${favicon}` }]}
         >
           <html lang="zh-CN" />
-          <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
         </Helmet>
 
         {/* 导航 */}


### PR DESCRIPTION
- 修改添加 `format-detection meta` 的方法
- 发现原来的添加方式会覆盖掉页面的 `DK` 信息